### PR TITLE
LSD v0.1.0-beta - adds dropdown component control props

### DIFF
--- a/packages/lsd-react/src/components/Dropdown/Dropdown.tsx
+++ b/packages/lsd-react/src/components/Dropdown/Dropdown.tsx
@@ -69,14 +69,18 @@ export const Dropdown: React.FC<DropdownProps> & {
     },
   })
 
+  const handleToggle = (open: boolean) => {
+    if (isControlled) {
+      onToggle && onToggle(open)
+    } else {
+      setOpenState(open)
+    }
+  }
+
   const onTrigger = () => {
     if (disabled) return
 
-    if (isControlled) {
-      onToggle && onToggle(!open)
-    } else {
-      setOpenState(!open)
-    }
+    handleToggle(!open)
   }
 
   useEffect(() => {
@@ -161,13 +165,7 @@ export const Dropdown: React.FC<DropdownProps> & {
         <DropdownMenu
           handleRef={containerRef}
           open={open}
-          onClose={() => {
-            if (isControlled) {
-              onToggle && onToggle(false)
-            } else {
-              setOpenState(false)
-            }
-          }}
+          onClose={() => handleToggle(false)}
           size={size}
           genericFontFamily={props.genericFontFamily}
         >

--- a/packages/lsd-react/src/components/Dropdown/Dropdown.tsx
+++ b/packages/lsd-react/src/components/Dropdown/Dropdown.tsx
@@ -83,10 +83,9 @@ export const Dropdown: React.FC<DropdownProps> & {
     handleToggle(!openState)
   }
 
-  // Handle the controlled version of the component:
   useEffect(() => {
-    typeof isOpen !== 'undefined' && setOpenState(isOpen)
-  }, [isOpen])
+    if (disabled && openState && !isControlled) setOpenState(false)
+  }, [openState, disabled, isControlled])
 
   const buttonId = props?.id ?? (props.id || 'dropdown') + '-input'
 

--- a/packages/lsd-react/src/components/Dropdown/Dropdown.tsx
+++ b/packages/lsd-react/src/components/Dropdown/Dropdown.tsx
@@ -59,6 +59,8 @@ export const Dropdown: React.FC<DropdownProps> & {
   const isControlled = isOpen !== undefined
   const [openState, setOpenState] = useState(false)
 
+  if (isControlled && isOpen !== openState) setOpenState(isOpen)
+
   const { select, isSelected, selected } = useSelect(options, value, {
     multi,
     onChange,
@@ -80,10 +82,6 @@ export const Dropdown: React.FC<DropdownProps> & {
 
     handleToggle(!openState)
   }
-
-  useEffect(() => {
-    if (disabled && openState && !isControlled) setOpenState(false)
-  }, [open, disabled, isControlled])
 
   // Handle the controlled version of the component:
   useEffect(() => {

--- a/packages/lsd-react/src/components/Dropdown/Dropdown.tsx
+++ b/packages/lsd-react/src/components/Dropdown/Dropdown.tsx
@@ -59,8 +59,6 @@ export const Dropdown: React.FC<DropdownProps> & {
   const isControlled = isOpen !== undefined
   const [openState, setOpenState] = useState(false)
 
-  const open = isControlled ? isOpen : openState
-
   const { select, isSelected, selected } = useSelect(options, value, {
     multi,
     onChange,
@@ -80,12 +78,17 @@ export const Dropdown: React.FC<DropdownProps> & {
   const onTrigger = () => {
     if (disabled) return
 
-    handleToggle(!open)
+    handleToggle(!openState)
   }
 
   useEffect(() => {
-    if (disabled && open && !isControlled) setOpenState(false)
+    if (disabled && openState && !isControlled) setOpenState(false)
   }, [open, disabled, isControlled])
+
+  // Handle the controlled version of the component:
+  useEffect(() => {
+    typeof isOpen !== 'undefined' && setOpenState(isOpen)
+  }, [isOpen])
 
   const buttonId = props?.id ?? (props.id || 'dropdown') + '-input'
 
@@ -100,7 +103,7 @@ export const Dropdown: React.FC<DropdownProps> & {
         dropdownClasses[size],
         error && dropdownClasses.error,
         disabled && dropdownClasses.disabled,
-        open && dropdownClasses.open,
+        openState && dropdownClasses.open,
         variant === 'outlined'
           ? dropdownClasses.outlined
           : dropdownClasses.outlinedBottom,
@@ -137,7 +140,7 @@ export const Dropdown: React.FC<DropdownProps> & {
               <ErrorIcon color="primary" className={dropdownClasses.icon} />
             )}
 
-            {open ? (
+            {openState ? (
               <ArrowUpIcon
                 color="primary"
                 className={dropdownClasses.menuIcon}
@@ -164,7 +167,7 @@ export const Dropdown: React.FC<DropdownProps> & {
       <Portal id="dropdown">
         <DropdownMenu
           handleRef={containerRef}
-          open={open}
+          open={openState}
           onClose={() => handleToggle(false)}
           size={size}
           genericFontFamily={props.genericFontFamily}


### PR DESCRIPTION
@jeangovil I added a couple of props to the dropdown component. Is this what you were thinking about?

Small description: when the isOpen prop is passed in, the dropdown component becomes controlled. The parent components can then use the onToggle function to check when the dropdown should be opened / closed, and control the dropdown's functionality accordingly. 

Related issue:

https://github.com/acid-info/lsd/issues/56