### PR TITLE
Designer's feedback - fix modal's close icon position

### DIFF
--- a/packages/lsd-react/src/components/Modal/Modal.styles.ts
+++ b/packages/lsd-react/src/components/Modal/Modal.styles.ts
@@ -21,6 +21,8 @@ export const ModalStyles = css`
   }
 
   .${modalClasses.modalContainer} {
+    position: relative;
+
     background: rgb(var(--lsd-surface-primary));
     padding: 20px;
 
@@ -43,6 +45,9 @@ export const ModalStyles = css`
   }
 
   .${modalClasses.closeIcon} {
+    position: absolute;
+    top: 8px;
+    right: 8px;
     cursor: pointer;
   }
 


### PR DESCRIPTION
Fixes modal's close icon position. It used to be like this:

![Screenshot from 2023-10-05 00-07-49](https://github.com/acid-info/lsd/assets/9993816/676ba1f7-87b1-4b06-aacd-0a42a914b820)

Now it's like this:

![Screenshot from 2023-10-05 00-07-38](https://github.com/acid-info/lsd/assets/9993816/2efa3f7f-9aaf-4621-aa78-96b1eaa9b1a8)

