### PR TITLE
LSD v0.1.0-beta - Adds spacing array to the theme definitions

### DIFF
--- a/packages/lsd-react/.storybook/themes.ts
+++ b/packages/lsd-react/.storybook/themes.ts
@@ -8,6 +8,7 @@ const themeProps: CreateThemeProps = {
   breakpoints: {},
   palette: {},
   typographyGlobal: {},
+  spacing: [],
 }
 
 const createThemes = () => {

--- a/packages/lsd-react/src/components/Theme/baseTheme.ts
+++ b/packages/lsd-react/src/components/Theme/baseTheme.ts
@@ -201,6 +201,7 @@ export const baseTheme: Theme = {
       secondary: '255, 255, 255',
     },
   },
+  spacing: [4, 8, 16, 24, 32, 40, 64, 80, 96, 120],
   globalStyles: css``,
   cssVars: '',
 }

--- a/packages/lsd-react/src/components/Theme/createTheme.ts
+++ b/packages/lsd-react/src/components/Theme/createTheme.ts
@@ -141,6 +141,7 @@ export const createTheme = (
     palette: createPaletteStyles(props, from),
     globalStyles: css``,
     cssVars: '',
+    spacing: props.spacing.length ? props.spacing : from.spacing,
   }
 
   const { cssVars, globalStyles } = createThemeGlobalStyles(theme)

--- a/packages/lsd-react/src/components/Theme/defaultThemes.ts
+++ b/packages/lsd-react/src/components/Theme/defaultThemes.ts
@@ -8,6 +8,7 @@ const lightTheme = createTheme(
     typography: {},
     typographyGlobal: {},
     palette: {},
+    spacing: [],
   },
   baseTheme,
 )
@@ -22,6 +23,7 @@ const darkTheme = createTheme(
       primary: '255, 255, 255',
       secondary: '0, 0, 0',
     },
+    spacing: [],
   },
   lightTheme,
 )

--- a/packages/lsd-react/src/components/Theme/globalStyles.ts
+++ b/packages/lsd-react/src/components/Theme/globalStyles.ts
@@ -87,6 +87,14 @@ const generateThemeGlobalStyles = (theme: Theme) => {
     )
   }
 
+  // Spacing-related CSS variable definitions
+  {
+    theme.spacing.map((spacingValue) => {
+      const varName = cssUtils.vars.lsd('spacing', spacingValue.toString())
+      vars.push(cssUtils.define(varName, `${spacingValue}px`))
+    })
+  }
+
   THEME_BREAKPOINTS.map((breakpoint, index) => {
     styles.push(`@media (min-width: ${theme.breakpoints[breakpoint].width}px) {
       :root {

--- a/packages/lsd-react/src/components/Theme/types.ts
+++ b/packages/lsd-react/src/components/Theme/types.ts
@@ -77,6 +77,7 @@ export type Theme = {
   palette: ThemePalette
   globalStyles: SerializedStyles
   cssVars: string
+  spacing: number[]
 }
 
 export type ThemeOptionBreakpointStyles = Partial<
@@ -100,6 +101,7 @@ export type CreateThemeProps = {
   typography: ThemeOptionTypography
   typographyGlobal: Partial<GlobalTypographyStyles>
   palette: ThemeOptionPalette
+  spacing: number[]
 }
 
 export type ThemeContext = {


### PR DESCRIPTION
Adds spacing values to the theme definitions. New CSS global vars are create for spacing. We can then use these CSS vars like so:

`margin-left: var(--lsd-spacing-120);`

[Figma link](https://www.figma.com/file/DVfLHVRl8adBPYkgq02Qki/LSD-%E2%80%93-Radical?type=design&node-id=3876-125588&mode=design&t=H9Ri2wM9mtnGo3N5-4)

[Notion link](https://www.notion.so/Theme-vars-Radical-style-v0-1-beta-d0e03a75a2f64404996e0ff77a576852)

### Note regarding the figma desings:

- There are 2 sections on the figma designs - the primitives and the tokens. The default values I'm currently using are the ones from the tokens section. I can change this is anyone thinks it makes sense.

### How to test this

- I didn't create a storybook file for this, as it's not a component (I can create 1 if people think it makes sense). I tested by going to a component styles file, and changing the css to include any of the new spacing vars, like I mentioned above for example: `margin-left: var(--lsd-spacing-120);`