### PR TITLE
Adds bottom border to non selected tab items

### DIFF
--- a/packages/lsd-react/src/components/TabItem/TabItem.classes.ts
+++ b/packages/lsd-react/src/components/TabItem/TabItem.classes.ts
@@ -8,4 +8,6 @@ export const tabItemClasses = {
   small: 'lsd-tab-item--small',
   medium: 'lsd-tab-item--medium',
   large: 'lsd-tab-item--large',
+
+  tabWithoutIcon: 'lsd-tab-item--without-icon',
 }

--- a/packages/lsd-react/src/components/TabItem/TabItem.classes.ts
+++ b/packages/lsd-react/src/components/TabItem/TabItem.classes.ts
@@ -9,5 +9,5 @@ export const tabItemClasses = {
   medium: 'lsd-tab-item--medium',
   large: 'lsd-tab-item--large',
 
-  tabWithoutIcon: 'lsd-tab-item--without-icon',
+  withIcon: 'lsd-tab-item--with-icon',
 }

--- a/packages/lsd-react/src/components/TabItem/TabItem.styles.ts
+++ b/packages/lsd-react/src/components/TabItem/TabItem.styles.ts
@@ -41,6 +41,10 @@ export const TabItemStyles = css`
     }
   }
 
+  .${tabItemClasses.tabWithoutIcon} {
+    justify-content: center;
+  }
+
   .${tabItemClasses.disabled} {
     cursor: default;
     opacity: 0.34;

--- a/packages/lsd-react/src/components/TabItem/TabItem.styles.ts
+++ b/packages/lsd-react/src/components/TabItem/TabItem.styles.ts
@@ -10,7 +10,7 @@ export const TabItemStyles = css`
     display: flex;
     flex-direction: row;
     align-items: center;
-    justify-content: space-between;
+    justify-content: center;
 
     &:hover {
       text-decoration: underline;
@@ -41,8 +41,8 @@ export const TabItemStyles = css`
     }
   }
 
-  .${tabItemClasses.tabWithoutIcon} {
-    justify-content: center;
+  .${tabItemClasses.withIcon} {
+    justify-content: space-between;
   }
 
   .${tabItemClasses.disabled} {

--- a/packages/lsd-react/src/components/TabItem/TabItem.styles.ts
+++ b/packages/lsd-react/src/components/TabItem/TabItem.styles.ts
@@ -15,6 +15,12 @@ export const TabItemStyles = css`
     &:hover {
       text-decoration: underline;
     }
+
+    &:not(${tabItemClasses.selected}) {
+      border-bottom: 1px solid rgb(var(--lsd-border-primary));
+    }
+
+    box-sizing: border-box;
   }
 
   .${tabItemClasses.text} {

--- a/packages/lsd-react/src/components/TabItem/TabItem.tsx
+++ b/packages/lsd-react/src/components/TabItem/TabItem.tsx
@@ -51,6 +51,7 @@ export const TabItem: React.FC<TabItemProps> & {
         tabItemClasses[size],
         selected && tabItemClasses.selected,
         props.disabled && tabItemClasses.disabled,
+        !icon && tabItemClasses.tabWithoutIcon,
       )}
       onClick={onClick}
     >

--- a/packages/lsd-react/src/components/TabItem/TabItem.tsx
+++ b/packages/lsd-react/src/components/TabItem/TabItem.tsx
@@ -51,7 +51,7 @@ export const TabItem: React.FC<TabItemProps> & {
         tabItemClasses[size],
         selected && tabItemClasses.selected,
         props.disabled && tabItemClasses.disabled,
-        !icon && tabItemClasses.tabWithoutIcon,
+        !!icon && tabItemClasses.withIcon,
       )}
       onClick={onClick}
     >

--- a/packages/lsd-react/src/components/Tabs/Tabs.styles.ts
+++ b/packages/lsd-react/src/components/Tabs/Tabs.styles.ts
@@ -1,5 +1,6 @@
 import { css } from '@emotion/react'
 import { tabsClasses } from './Tabs.classes'
+import { tabItemClasses } from '../TabItem/TabItem.classes'
 
 export const TabsStyles = css`
   .${tabsClasses.root} {
@@ -7,8 +8,17 @@ export const TabsStyles = css`
     flex-direction: row;
     overflow: auto;
 
+    width: fit-content;
+    max-width: 100%;
+
     & > * {
       flex-shrink: 0;
+    }
+
+    border-bottom: 1px solid rgb(var(--lsd-border-primary));
+
+    .${tabItemClasses.root} {
+      border-bottom: none;
     }
   }
 


### PR DESCRIPTION
Adds bottom border to non selected tab items.

[Figma link](https://www.figma.com/file/DVfLHVRl8adBPYkgq02Qki/LSD-%E2%80%93-Radical?type=design&node-id=2305-311577&mode=design&t=URx9ExagMfdktgnd-0)

edit: another fix was made: Ihor said the tabs' content should be centered when there's no icon.