### PR TITLE
Broadcast height to parents - useful when storybook is inside an iframe

### DIFF
--- a/packages/lsd-react/.storybook/preview-head.html
+++ b/packages/lsd-react/.storybook/preview-head.html
@@ -1,0 +1,23 @@
+<script>
+  function sendHeightToParent() {
+    const height =
+      document.documentElement.scrollHeight || document.body.scrollHeight
+    window.parent.postMessage(
+      {
+        type: 'iframeResize',
+        height: height,
+      },
+      '*',
+    )
+  }
+
+  document.addEventListener('DOMContentLoaded', function () {
+    // Send initial height.
+    sendHeightToParent()
+
+    // Ensure the interval is set only once.
+    if (!window.heightIntervalSet) {
+      window.heightIntervalSet = setInterval(sendHeightToParent, 1000)
+    }
+  })
+</script>


### PR DESCRIPTION
### Note: I'm not sure if this will work. It works on my PC, on localhost - but it can fail in prod.

Sends message to parent window saying the current document's height. 

This was done to know the correct height for component pages on the logos brand guidelines site. As we can see from the following example, the current approach is to default to 6000 pixels:

[](https://logos-brand-guidelines.vercel.app/lsd/components/Autocomplete)

This is because iframe's don't stretch to their children's height, and we can't possibly know the iframe's size: if we try to access the iframe's document, we get a CORS error. To solve this issue, in this PR, a new script was added to storybook that broadcasts the iframe's height every 1 second. This way, the parent windows can listen to the broadcasted messages and adjust the iframe's size accordingly.

### How to test locally

1. Run storybook locally. Get the localhost url - mine was http://localhost:6006
2. Run the logos brand guidelines site locally. Change one of the component's storyBook prop to `storybookUrl="http://localhost:6006` - and then go check the page with that component: the height of the iframe should be okay, without any scroll bars and without being too large (it used to be 6000 pixels by default).